### PR TITLE
Use pipenv in TravisCI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "3.7.4"
 install:
   - pip install pipenv
-  - pipenv install
+  - pipenv install --dev
 script:
   - pycodestyle .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.7.4"
 install:
-  - pip install pycodestyle
+  - pip install pipenv
+  - pipenv install
 script:
   - pycodestyle .

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pycodestyle = "*"
 
 [packages]
 websockets = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7d453ed917cb5091c752cfe5caac404603167fc595826b3d9c4960aef46be38d"
+            "sha256": "28b27ca45d8d4cbcdfb87f8cd38932d0b60c6bccf40d18d7ff66d6277b6edcf2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -140,5 +140,14 @@
             "version": "==8.0.2"
         }
     },
-    "develop": {}
+    "develop": {
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "index": "pypi",
+            "version": "==2.5.0"
+        }
+    }
 }


### PR DESCRIPTION
Resolves #17

According to [this build fail](https://travis-ci.com/PurdueElectricRacing/Wireless-Telemetry-Server/builds/124575384), TravisCI is not using the `pipenv` required to install everything.